### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+# workflow name
+name: Generate release-artifacts
+
+# on events
+on:
+  release:
+    types: 
+        - created
+
+# workflow tasks
+jobs:
+  generate:
+    name: Generate cross-platform builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Generate build files
+        uses: thatisuday/go-cross-build@v1
+        with:
+            platforms: 'linux/amd64, darwin/amd64, windows/amd64'
+            package: ''
+            name: 'smee-client-go'
+            compress: 'true'
+            dest: 'dist'
+      - name: Copy build-artifacts
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: "./dist/*.tar.gz"
+ 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module smee-client-go
+
+go 1.17
+
+require (
+	github.com/buger/jsonparser v1.1.1
+	github.com/jessevdk/go-flags v1.5.0
+)
+
+require golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 // indirect


### PR DESCRIPTION
To make it easier for people to use the program. 

The official smee-client depend on nodeJS to run, but this one does not require any dependency and it is available for all platforms.